### PR TITLE
[codex] Keep last good XMLTV output on fetch failure

### DIFF
--- a/fetch_json.sh
+++ b/fetch_json.sh
@@ -1,9 +1,29 @@
 #!/bin/bash
 # Scheduled update of Schedules Direct data
 
+set -o pipefail
+
+output=/var/www/html/tvxml.xml
+tmp_output="${output}.new"
+
 echo "$(date '+%Y-%m-%d %H:%M:%S') - [SCHEDULED SYNC] Starting Schedules Direct data fetch..."
 
-# Run the tv_grab_zz_sdjson command with the config file
-/usr/bin/tv_grab_zz_sdjson --config-file /var/www/html/tv_grab_zz_sdjson.conf --output /var/www/html/tvxml.xml --days ${SD_FETCH_DAYS}
+rm -f "${tmp_output}"
+
+if /usr/bin/tv_grab_zz_sdjson --config-file /var/www/html/tv_grab_zz_sdjson.conf --output "${tmp_output}" --days "${SD_FETCH_DAYS}"; then
+  if [ -s "${tmp_output}" ] && head -c 200 "${tmp_output}" | grep -Eq '<\?xml|<tv'; then
+    mv "${tmp_output}" "${output}"
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - [SCHEDULED SYNC] Replaced ${output} with $(stat -c %s "${output}") bytes"
+  else
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - [SCHEDULED SYNC] Refusing to replace ${output}; temp output was empty or not XML" >&2
+    rm -f "${tmp_output}"
+    exit 2
+  fi
+else
+  rc=$?
+  echo "$(date '+%Y-%m-%d %H:%M:%S') - [SCHEDULED SYNC] Fetch failed with exit ${rc}; keeping existing ${output}" >&2
+  rm -f "${tmp_output}"
+  exit "${rc}"
+fi
 
 echo "$(date '+%Y-%m-%d %H:%M:%S') - [SCHEDULED SYNC] Completed Schedules Direct data fetch"

--- a/start.sh
+++ b/start.sh
@@ -44,7 +44,7 @@ rm -f /var/www/html/tv_grab_zz_sdjson.cache || echo "No cache file to clean"
 
 # Initial run of the grab command
 echo "$(date '+%Y-%m-%d %H:%M:%S') - [INITIAL SYNC] Starting Schedules Direct data fetch..."
-tv_grab_zz_sdjson --config-file /var/www/html/tv_grab_zz_sdjson.conf --output /var/www/html/tvxml.xml --days $fetch_days
+/fetch_json.sh
 echo "$(date '+%Y-%m-%d %H:%M:%S') - [INITIAL SYNC] Completed Schedules Direct data fetch"
 
 # Set up log rotation for cron.log

--- a/tvgrab-cron
+++ b/tvgrab-cron
@@ -1,1 +1,1 @@
-0 0 * * * /bin/bash -c 'echo "$(date "+\%Y-\%m-\%d \%H:\%M:\%S") - [SCHEDULED SYNC - CRON] Starting Schedules Direct data fetch..." > /proc/1/fd/1 2>/proc/1/fd/2 && tv_grab_zz_sdjson --config-file /var/www/html/tv_grab_zz_sdjson.conf --output /var/www/html/tvxml.xml --days $SD_FETCH_DAYS > /proc/1/fd/1 2>/proc/1/fd/2 && echo "$(date "+\%Y-\%m-\%d \%H:\%M:\%S") - [SCHEDULED SYNC - CRON] Completed Schedules Direct data fetch" > /proc/1/fd/1 2>/proc/1/fd/2'
+0 0 * * * /fetch_json.sh > /proc/1/fd/1 2>/proc/1/fd/2


### PR DESCRIPTION
## Summary
- write `tv_grab_zz_sdjson` output to a temporary XMLTV file first
- only replace `tvxml.xml` after the new output is non-empty and appears to be XML
- route both cron and startup refreshes through the same safe fetch wrapper

## Why
A transient Schedules Direct/API failure can currently leave the served `/var/www/html/tvxml.xml` as a 0-byte file because `tv_grab_zz_sdjson` writes directly to the published output path. Downstream EPG consumers can then import the empty file and clear their guide data.

This keeps the last known-good XMLTV file in place when a fetch fails or produces invalid/empty output.

Observed failure case: Schedules Direct returned `502 Bad Gateway` during a `/programs` request; the published XMLTV file became 0 bytes, and the EPG consumer imported 0 channels / 0 programs.

## Validation
- `bash -n fetch_json.sh`
- `bash -n start.sh`
- tested the same safe temp-file/move pattern against a live deployment after the failure and restored a valid XMLTV file without truncating on errors
