### PR TITLE
Improve error reporting with status page and detailed logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get install -y bash
 RUN apt-get install -y xmltv-util
-RUN apt-get install -y nginx
+RUN apt-get install -y nginx python3
 # Install cron in addition to your other packages
 RUN apt-get update && apt-get install -y cron
 
@@ -18,6 +18,7 @@ COPY tvgrab-cron /etc/cron.d/tvgrab-cron
 RUN chmod 0644 /etc/cron.d/tvgrab-cron
 
 # Create an entrypoint script to generate the config with the password
+COPY index.nginx-debian.html /var/www/html/index.html
 COPY start.sh /start.sh
 COPY fetch_json.sh /fetch_json.sh
 RUN chmod +x /start.sh /fetch_json.sh

--- a/fetch_json.sh
+++ b/fetch_json.sh
@@ -5,24 +5,46 @@ set -o pipefail
 
 output=/var/www/html/tvxml.xml
 tmp_output="${output}.new"
+status_file=/var/www/html/status.json
+error_log=/var/www/html/last_error.log
 
 echo "$(date '+%Y-%m-%d %H:%M:%S') - [SCHEDULED SYNC] Starting Schedules Direct data fetch..."
 
 rm -f "${tmp_output}"
 
-if /usr/bin/tv_grab_zz_sdjson --config-file /var/www/html/tv_grab_zz_sdjson.conf --output "${tmp_output}" --days "${SD_FETCH_DAYS}"; then
+# Capture both stdout and stderr from tv_grab_zz_sdjson
+stderr_tmp=$(mktemp)
+/usr/bin/tv_grab_zz_sdjson --config-file /var/www/html/tv_grab_zz_sdjson.conf --output "${tmp_output}" --days "${SD_FETCH_DAYS}" 2>"${stderr_tmp}"
+rc=$?
+
+if [ ${rc} -eq 0 ]; then
   if [ -s "${tmp_output}" ] && head -c 200 "${tmp_output}" | grep -Eq '<\?xml|<tv'; then
     mv "${tmp_output}" "${output}"
-    echo "$(date '+%Y-%m-%d %H:%M:%S') - [SCHEDULED SYNC] Replaced ${output} with $(stat -c %s "${output}") bytes"
+    file_size=$(stat -c %s "${output}")
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - [SCHEDULED SYNC] Replaced ${output} with ${file_size} bytes"
+    # Write success status
+    cat > "${status_file}" << EOF
+{"status":"ok","last_success":"$(date -Iseconds)","file_size":${file_size},"error":null}
+EOF
+    rm -f "${error_log}" "${stderr_tmp}"
   else
     echo "$(date '+%Y-%m-%d %H:%M:%S') - [SCHEDULED SYNC] Refusing to replace ${output}; temp output was empty or not XML" >&2
-    rm -f "${tmp_output}"
+    cat > "${status_file}" << EOF
+{"status":"error","last_failure":"$(date -Iseconds)","exit_code":2,"error":"Output was empty or not valid XML"}
+EOF
+    rm -f "${tmp_output}" "${stderr_tmp}"
     exit 2
   fi
 else
-  rc=$?
+  error_output=$(cat "${stderr_tmp}")
   echo "$(date '+%Y-%m-%d %H:%M:%S') - [SCHEDULED SYNC] Fetch failed with exit ${rc}; keeping existing ${output}" >&2
-  rm -f "${tmp_output}"
+  echo "$(date '+%Y-%m-%d %H:%M:%S') - [SCHEDULED SYNC] stderr: ${error_output}" >&2
+  # Persist error details
+  echo "${error_output}" > "${error_log}"
+  cat > "${status_file}" << EOF
+{"status":"error","last_failure":"$(date -Iseconds)","exit_code":${rc},"error":$(echo "${error_output}" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read().strip()))' 2>/dev/null || echo "\"${error_output}\"")}
+EOF
+  rm -f "${tmp_output}" "${stderr_tmp}"
   exit "${rc}"
 fi
 

--- a/index.nginx-debian.html
+++ b/index.nginx-debian.html
@@ -1,23 +1,38 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Welcome to nginx!</title>
+<title>Schedules Direct XMLTV Service</title>
+<meta http-equiv="refresh" content="60">
 <style>
 html { color-scheme: light dark; }
-body { width: 35em; margin: 0 auto;
-font-family: Tahoma, Verdana, Arial, sans-serif; }
+body { max-width: 40em; margin: 2em auto; font-family: system-ui, sans-serif; padding: 0 1em; }
+.ok { color: #2d7; }
+.error { color: #e44; }
+pre { background: #1a1a1a; color: #eee; padding: 1em; overflow-x: auto; border-radius: 4px; }
 </style>
 </head>
 <body>
-<h1>Welcome to nginx!</h1>
-<p>If you see this page, the nginx web server is successfully installed and
-working. Further configuration is required.</p>
-
-<p>For online documentation and support please refer to
-<a href="http://nginx.org/">nginx.org</a>.<br/>
-Commercial support is available at
-<a href="http://nginx.com/">nginx.com</a>.</p>
-
-<p><em>Thank you for using nginx.</em></p>
+<h1>Schedules Direct XMLTV Service</h1>
+<div id="status">Loading...</div>
+<h2>Endpoints</h2>
+<ul>
+<li><a href="/tvxml.xml">/tvxml.xml</a> — XMLTV guide data</li>
+<li><a href="/status.json">/status.json</a> — machine-readable status</li>
+<li><a href="/last_error.log">/last_error.log</a> — last error output (if any)</li>
+</ul>
+<script>
+fetch('/status.json').then(r=>r.json()).then(s=>{
+  const d=document.getElementById('status');
+  if(s.status==='ok'){
+    d.innerHTML=`<p class="ok"><strong>✓ Healthy</strong></p>
+      <p>Last success: ${s.last_success}<br>File size: ${(s.file_size/1024).toFixed(0)} KB</p>`;
+  } else {
+    d.innerHTML=`<p class="error"><strong>✗ Error (exit code ${s.exit_code})</strong></p>
+      <p>Last failure: ${s.last_failure}</p><pre>${s.error||'Unknown error'}</pre>`;
+  }
+}).catch(()=>{
+  document.getElementById('status').innerHTML='<p>No status yet — waiting for first fetch to complete.</p>';
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Surfaces detailed error information when `tv_grab_zz_sdjson` fails, so users can diagnose issues without exec'ing into the container.

## Changes

- **`fetch_json.sh`**: Captures stderr from `tv_grab_zz_sdjson`, persists it to `/var/www/html/last_error.log`, and writes structured `/var/www/html/status.json` with exit code + error message
- **`index.nginx-debian.html`**: Status dashboard replacing the default nginx page — shows health/error state with auto-refresh
- **`Dockerfile`**: Adds `python3` for JSON encoding, copies status page HTML

## New Endpoints

| Path | Description |
|------|-------------|
| `/` | Status dashboard (auto-refreshes every 60s) |
| `/status.json` | Machine-readable status with exit code and error |
| `/last_error.log` | Raw stderr from last failed fetch |
| `/tvxml.xml` | XMLTV data (unchanged) |

## Context

Addresses #8 — users experiencing exit code 22 can now see the actual error message from Schedules Direct without needing shell access.

## Testing

- `bash -n` syntax check passes on both shell scripts
- Docker build not tested locally (daemon not running) but changes are minimal and well-scoped